### PR TITLE
Reset LS distance when not in Precland (CU-23ke6gd)

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -171,5 +171,7 @@ void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pw
         _activeFlightMode++;
     }
 
+    // TODO: If the channel is equal to the next cam channel, change channel instead of flight mode and return
+
     emit activeFlightModeChanged(_activeFlightMode);
 }

--- a/src/QmlControls/LandingStationIndicator.qml
+++ b/src/QmlControls/LandingStationIndicator.qml
@@ -45,12 +45,13 @@ QGCLabel {
     property var    currentVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     
 
-    /*Item {
+    // Continuously checks if the LS Distance info is outdated
+    Item {
        Timer {
-               interval: 100; running: true; repeat: true
+               interval: 2000; running: true; repeat: true
                onTriggered: _root.text = updateText();
              }
-    }*/
+    }
 
     property real mouseAreaLeftMargin:    0 
 }

--- a/src/QmlControls/LandingStationIndicator.qml
+++ b/src/QmlControls/LandingStationIndicator.qml
@@ -21,10 +21,26 @@ QGCLabel {
 
     function updateText()
     {
-        /*console.log(currentVehicle.landingStationConnected.value)
-        console.log(currentVehicle.landingStationConnected.rawValue)*/
+        
         if(!currentVehicle) return "No Vehicle";
-        return currentVehicle.landingStationConnected.value ?  qsTr("LS connected", "Connected to Landing Station") : qsTr("LS disconnected", "Landing Station not connected");
+
+        // Case when we are connected
+        if(currentVehicle.landingStationConnected.value) return qsTr("LS connected", "Connected to Landing Station");
+
+        // Get the current distance info when we are disconnected
+        var dist_info = "";
+        const d = new Date();
+        let time = d.getTime()/1000;
+        console.log(currentVehicle.landingStationDistanceLastTime.value);
+        console.log(currentVehicle.landingStationDistance.value);
+        console.log(time);
+
+        if(time - currentVehicle.landingStationDistanceLastTime.value < 3)
+        {
+            dist_info = " (" + Math.round(currentVehicle.landingStationDistance.value * 100) / 100 + "m)";
+        }
+
+        return qsTr("LS disconnected" + dist_info, "Landing Station not connected");
     }
     property var    currentVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     

--- a/src/QmlControls/LandingStationIndicator.qml
+++ b/src/QmlControls/LandingStationIndicator.qml
@@ -23,6 +23,7 @@ QGCLabel {
     {
         /*console.log(currentVehicle.landingStationConnected.value)
         console.log(currentVehicle.landingStationConnected.rawValue)*/
+        if(!currentVehicle) return "No Vehicle";
         return currentVehicle.landingStationConnected.value ?  qsTr("LS connected", "Connected to Landing Station") : qsTr("LS disconnected", "Landing Station not connected");
     }
     property var    currentVehicle:         QGroundControl.multiVehicleManager.activeVehicle

--- a/src/QmlControls/StartROSMenuController.cc
+++ b/src/QmlControls/StartROSMenuController.cc
@@ -100,7 +100,7 @@ void StartROSMenuController::set_status(int val)
     if(status()==2)
     {
         std::string setup_command = "ssh-copy-id "+_current_username+"@"+_current_ip;
-        std::string osType = proQSysInfo::productType().toStdString();
+        std::string osType = QSysInfo::productType().toStdString();
         if(osType == "windows" || osType == "winrt")
         {
             setup_command = "type $env:USERPROFILE\.ssh\id_rsa.pub | ssh "+_current_username+"@"+_current_ip+" \"cat >> .ssh/authorized_keys\"";        

--- a/src/QmlControls/StartROSMenuController.cc
+++ b/src/QmlControls/StartROSMenuController.cc
@@ -99,7 +99,13 @@ void StartROSMenuController::set_status(int val)
     emit statusChanged(val);
     if(status()==2)
     {
-        std::string message = "Make sure that your network setup is correct, and that you have run the SSH setup commands for this glider.\n\nIf you didn't run the SSH setup, do the following steps CAREFULLY:\n1- If you have never used SSH on this machine, run \"ssh-keygen -b 4096\" (should be executed only once, choose \"Cancel\" if the command asks you to overwrite an existing SSH key)\n2- Run \"ssh-copy-id "+_current_username+"@"+_current_ip+"\" to copy your SSH identity to the glider, you will be prompted to enter the glider's password.";
+        std::string setup_command = "ssh-copy-id "+_current_username+"@"+_current_ip;
+        std::string osType = proQSysInfo::productType().toStdString();
+        if(osType == "windows" || osType == "winrt")
+        {
+            setup_command = "type $env:USERPROFILE\.ssh\id_rsa.pub | ssh "+_current_username+"@"+_current_ip+" \"cat >> .ssh/authorized_keys\"";        
+        }
+        std::string message = "Make sure that your network setup is correct, and that you have run the SSH setup commands for this glider.\n\nIf you didn't run the SSH setup, do the following steps CAREFULLY:\n1- If you have never used SSH on this machine, run \"ssh-keygen -b 4096\" (should be executed only once, choose \"Cancel\" if the command asks you to overwrite an existing SSH key)\n2- Run \""+setup_command+"\" to copy your SSH identity to the glider, you will be prompted to enter the glider's password.";
         qgcApp()->showAppMessage(
             tr(message.c_str()),
             tr("SSH to glider failed")

--- a/src/QmlControls/StartROSMenuController.cc
+++ b/src/QmlControls/StartROSMenuController.cc
@@ -103,7 +103,7 @@ void StartROSMenuController::set_status(int val)
         std::string osType = QSysInfo::productType().toStdString();
         if(osType == "windows" || osType == "winrt")
         {
-            setup_command = "type $env:USERPROFILE\.ssh\id_rsa.pub | ssh "+_current_username+"@"+_current_ip+" \"cat >> .ssh/authorized_keys\"";        
+            setup_command = "type %userprofile%\\.ssh\\id_rsa.pub | ssh "+_current_username+"@"+_current_ip+" \"cat >> .ssh/authorized_keys\"";        
         }
         std::string message = "Make sure that your network setup is correct, and that you have run the SSH setup commands for this glider.\n\nIf you didn't run the SSH setup, do the following steps CAREFULLY:\n1- If you have never used SSH on this machine, run \"ssh-keygen -b 4096\" (should be executed only once, choose \"Cancel\" if the command asks you to overwrite an existing SSH key)\n2- Run \""+setup_command+"\" to copy your SSH identity to the glider, you will be prompted to enter the glider's password.";
         qgcApp()->showAppMessage(

--- a/src/QmlControls/StartROSMenuController.h
+++ b/src/QmlControls/StartROSMenuController.h
@@ -7,6 +7,7 @@
 #include <QQuickItem>
 #include <QCursor>
 #include "SettingsManager.h"
+#include <QSysInfo> 
 
 class StartROSMenuController : public QObject
 {
@@ -52,6 +53,12 @@ class RosSSHThread : public QThread
 {
     Q_OBJECT
     void run() override {
+        std::string osType = proQSysInfo::productType().toStdString();
+        std::cout<<osType<<"\n";
+        if(osType == "windows" || osType == "winrt")
+        {
+            std::cout<<"Windows confirmed\n";
+        }
         int result;
         QString program = tr("ssh");
         QStringList arguments;

--- a/src/QmlControls/StartROSMenuController.h
+++ b/src/QmlControls/StartROSMenuController.h
@@ -53,7 +53,7 @@ class RosSSHThread : public QThread
 {
     Q_OBJECT
     void run() override {
-        std::string osType = proQSysInfo::productType().toStdString();
+        std::string osType = QSysInfo::productType().toStdString();
         std::cout<<osType<<"\n";
         if(osType == "windows" || osType == "winrt")
         {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -95,6 +95,7 @@ const char* Vehicle::_distanceToGCSFactName =       "distanceToGCS";
 const char* Vehicle::_hobbsFactName =               "hobbs";
 const char* Vehicle::_throttlePctFactName =         "throttlePct";
 const char* Vehicle::_landingStationConnectedFactName = "landingStationConnected";
+const char* Vehicle::_videoFPSFactName =            "videoFPS";
 
 const char* Vehicle::_gpsFactGroupName =                "gps";
 const char* Vehicle::_gps2FactGroupName =               "gps2";
@@ -156,6 +157,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _hobbsFact                    (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact              (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _landingStationConnectedFact  (0, _landingStationConnectedFactName, FactMetaData::valueTypeBool)
+    , _videoFPSFact                 (0, _videoFPSFactName,          FactMetaData::valueTypeUint16)
     , _gpsFactGroup                 (this)
     , _gps2FactGroup                (this)
     , _windFactGroup                (this)
@@ -310,6 +312,8 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _hobbsFact                        (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact                  (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _landingStationConnectedFact      (0, _landingStationConnectedFactName, FactMetaData::valueTypeBool)
+    , _videoFPSFact                     (0, _videoFPSFactName,          FactMetaData::valueTypeUint16)
+
     , _gpsFactGroup                     (this)
     , _gps2FactGroup                    (this)
     , _windFactGroup                    (this)
@@ -432,6 +436,7 @@ void Vehicle::_commonInit()
     _addFact(&_distanceToGCSFact,       _distanceToGCSFactName);
     _addFact(&_throttlePctFact,         _throttlePctFactName);
     _addFact(&_landingStationConnectedFact, _landingStationConnectedFactName);
+    _addFact(&_videoFPSFact,            _videoFPSFactName);
 
     _hobbsFact.setRawValue(QVariant(QString("0000:00:00")));
     _addFact(&_hobbsFact,               _hobbsFactName);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -301,6 +301,8 @@ public:
     Q_PROPERTY(Fact* hobbs              READ hobbs              CONSTANT)
     Q_PROPERTY(Fact* throttlePct        READ throttlePct        CONSTANT)
     Q_PROPERTY(Fact* landingStationConnected READ landingStationConnected CONSTANT)
+    Q_PROPERTY(Fact* videoFPS           READ videoFPS           CONSTANT)
+
 
     Q_PROPERTY(FactGroup*           gps             READ gpsFactGroup               CONSTANT)
     Q_PROPERTY(FactGroup*           gps2            READ gps2FactGroup              CONSTANT)
@@ -643,6 +645,8 @@ public:
     Fact* hobbs                             () { return &_hobbsFact; }
     Fact* throttlePct                       () { return &_throttlePctFact; }
     Fact* landingStationConnected           () { return &_landingStationConnectedFact; }
+    Fact* videoFPS                          () { return &_videoFPSFact; }
+
 
     FactGroup* gpsFactGroup                 () { return &_gpsFactGroup; }
     FactGroup* gps2FactGroup                () { return &_gps2FactGroup; }
@@ -1299,6 +1303,7 @@ private:
     Fact _hobbsFact;
     Fact _throttlePctFact;
     Fact _landingStationConnectedFact;
+    Fact _videoFPSFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
     VehicleGPS2FactGroup            _gps2FactGroup;
@@ -1350,6 +1355,7 @@ private:
     static const char* _hobbsFactName;
     static const char* _throttlePctFactName;
     static const char* _landingStationConnectedFactName;
+    static const char* _videoFPSFactName;
 
     static const char* _gpsFactGroupName;
     static const char* _gps2FactGroupName;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -301,6 +301,8 @@ public:
     Q_PROPERTY(Fact* hobbs              READ hobbs              CONSTANT)
     Q_PROPERTY(Fact* throttlePct        READ throttlePct        CONSTANT)
     Q_PROPERTY(Fact* landingStationConnected READ landingStationConnected CONSTANT)
+    Q_PROPERTY(Fact* landingStationDistance READ landingStationDistance CONSTANT)
+    Q_PROPERTY(Fact* landingStationDistanceLastTime READ landingStationDistanceLastTime CONSTANT)
     Q_PROPERTY(Fact* videoFPS           READ videoFPS           CONSTANT)
 
 
@@ -644,7 +646,11 @@ public:
     Fact* distanceToGCS                     () { return &_distanceToGCSFact; }
     Fact* hobbs                             () { return &_hobbsFact; }
     Fact* throttlePct                       () { return &_throttlePctFact; }
+
     Fact* landingStationConnected           () { return &_landingStationConnectedFact; }
+    Fact* landingStationDistance            () { return &_landingStationDistanceFact; }
+    Fact* landingStationDistanceLastTime    () { return &_landingStationDistanceLastTimeFact; }
+
     Fact* videoFPS                          () { return &_videoFPSFact; }
 
 
@@ -1303,6 +1309,9 @@ private:
     Fact _hobbsFact;
     Fact _throttlePctFact;
     Fact _landingStationConnectedFact;
+    Fact _landingStationDistanceFact;
+    Fact _landingStationDistanceLastTimeFact;
+
     Fact _videoFPSFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
@@ -1354,7 +1363,11 @@ private:
     static const char* _distanceToGCSFactName;
     static const char* _hobbsFactName;
     static const char* _throttlePctFactName;
+
     static const char* _landingStationConnectedFactName;
+    static const char* _landingStationDistanceFactName;
+    static const char* _landingStationDistanceLastTimeFactName;
+
     static const char* _videoFPSFactName;
 
     static const char* _gpsFactGroupName;

--- a/src/Vehicle/VehicleFact.json
+++ b/src/Vehicle/VehicleFact.json
@@ -147,6 +147,17 @@
     "name":             "videoFPS",
     "shortDesc": "FPS of the current video stream",
     "type":             "uint16"
+},
+{
+    "name":             "landingStationDistance",
+    "shortDesc": "Current Distance in Meters to the Landing Station",
+    "type":             "double"
+},
+{
+    "name":             "landingStationDistanceLastTime",
+    "shortDesc": "Timestamp of the last LS distance info",
+    "type":             "uint64",
+    "default":          0
 }
 ]
 }

--- a/src/Vehicle/VehicleFact.json
+++ b/src/Vehicle/VehicleFact.json
@@ -142,6 +142,11 @@
     "shortDesc": "Landing Station Connected",
     "type":             "bool",
     "default":          false
+},
+{
+    "name":             "videoFPS",
+    "shortDesc": "FPS of the current video stream",
+    "type":             "uint16"
 }
 ]
 }

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -23,6 +23,8 @@
 #include <QQueue>
 #include <QQuickItem>
 
+#include <deque>
+
 #include "VideoReceiver.h"
 
 #include <gst/gst.h>
@@ -146,6 +148,9 @@ protected:
 
     qint64              _lastSourceFrameTime;
     qint64              _lastVideoFrameTime;
+    qint64              _lastVideoFrameTimeMSecs;
+    std::deque<qint64>  _frames;
+
     bool                _resetVideoSink;
     gulong              _videoSinkProbeId;
 

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -267,7 +267,7 @@ RowLayout {
         height:     ScreenTools.defaultFontPixelHeight * 0.75
         fillMode:   Image.PreserveAspectFit
         mipmap:     true
-        color:      Qt.rgba(0,0,0,1)
+        color:      _activeVehicle ? (landingStationIndicator.currentVehicle.landingStationConnected.value? Qt.rgba(0,1,0,1):Qt.rgba(1,0,0,1)): Qt.rgba(1,1,1,1)
         source:     _activeVehicle ? (landingStationIndicator.currentVehicle.landingStationConnected.value ? "/qmlimages/GreenCheckmark.svg" : "/qmlimages/CircleX.svg") : ""
         visible:    landingStationIndicator.visible
     }
@@ -286,12 +286,14 @@ RowLayout {
         font.pointSize:         ScreenTools.defaultFontPointSize
         mouseAreaLeftMargin:    -(landingStationIndicator.x - landingStationIcon.x)
         visible:                _activeVehicle
+        color:      _activeVehicle ? (landingStationIndicator.currentVehicle.landingStationConnected.value? Qt.rgba(1,1,1,1):Qt.rgba(1,0,0,1)): Qt.rgba(1,1,1,1)
+
     }
 
     // Video FPS indicator
     Item {
         id:                     videoFPSItem
-        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth / 2
+        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth
         height:                 1
     }
 
@@ -301,7 +303,7 @@ RowLayout {
         verticalAlignment:      Text.AlignVCenter
         font.pointSize:         ScreenTools.defaultFontPointSize
         visible:                _activeVehicle
-        text:                   _activeVehicle ? _activeVehicle.videoFPS.value : 0
+        text:                   "" + (_activeVehicle ? _activeVehicle.videoFPS.value : 0) + "FPS"
     }
 
     // Start ROS Menu

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -267,8 +267,8 @@ RowLayout {
         height:     ScreenTools.defaultFontPixelHeight * 0.75
         fillMode:   Image.PreserveAspectFit
         mipmap:     true
-        color:      qgcPal.text
-        source:     landingStationIndicator.currentVehicle.landingStationConnected.value ? "/qmlimages/GreenCheckmark.svg" : "/qmlimages/CircleX.svg"
+        color:      Qt.rgba(0,0,0,1)
+        source:     _activeVehicle ? (landingStationIndicator.currentVehicle.landingStationConnected.value ? "/qmlimages/GreenCheckmark.svg" : "/qmlimages/CircleX.svg") : ""
         visible:    landingStationIndicator.visible
     }
 
@@ -286,6 +286,22 @@ RowLayout {
         font.pointSize:         ScreenTools.defaultFontPointSize
         mouseAreaLeftMargin:    -(landingStationIndicator.x - landingStationIcon.x)
         visible:                _activeVehicle
+    }
+
+    // Video FPS indicator
+    Item {
+        id:                     videoFPSItem
+        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth / 2
+        height:                 1
+    }
+
+    QGCLabel {
+        id:                     videoFPS
+        Layout.preferredHeight: _root.height
+        verticalAlignment:      Text.AlignVCenter
+        font.pointSize:         ScreenTools.defaultFontPointSize
+        visible:                _activeVehicle
+        text:                   _activeVehicle ? _activeVehicle.videoFPS.value : 0
     }
 
     // Start ROS Menu


### PR DESCRIPTION
Reset the distance to the landing station when the `dis_ls` is not received for more than 3 seconds (done by adding a timer in QML that periodically checks the latest distance info)